### PR TITLE
fix: Align TokenList chevron button positioning with other components

### DIFF
--- a/packages/0xtrails/src/widget/components/TokenList.tsx
+++ b/packages/0xtrails/src/widget/components/TokenList.tsx
@@ -164,7 +164,7 @@ export const TokenList: React.FC<TokenListProps> = ({
             <button
               type="button"
               onClick={onBack}
-              className="p-2 rounded-full transition-colors cursor-pointer hover:trails-hover-bg text-gray-400"
+              className="p-2 -ml-2 rounded-full transition-colors cursor-pointer hover:trails-hover-bg text-gray-400"
             >
               <ChevronLeft className="h-6 w-6" />
             </button>


### PR DESCRIPTION
## Summary
• Add `-ml-2` margin to TokenList's back button to match consistent styling used in FundMethods, MeshConnect, and WalletConnect components
• Ensures consistent visual alignment across all widget chevron buttons

## Test plan
- [x] Verify TokenList back button now has proper alignment matching other components
- [ ] Test visual consistency across different theme modes
- [ ] Confirm button hover states work properly