### PR TITLE
fix: Remove mr-8 margin from TokenList total balance container

### DIFF
--- a/packages/0xtrails/src/widget/components/TokenList.tsx
+++ b/packages/0xtrails/src/widget/components/TokenList.tsx
@@ -185,7 +185,7 @@ export const TokenList: React.FC<TokenListProps> = ({
           mode !== "fund" &&
           fundMethod !== "qr-code" &&
           fundMethod !== "exchange" && (
-            <div className="text-right max-w-[125px] mr-8">
+            <div className="text-right max-w-[125px]">
               <p className={`text-xs ${"text-gray-500 dark:text-gray-400"}`}>
                 Total balance:
               </p>

--- a/packages/0xtrails/src/widget/components/TokenList.tsx
+++ b/packages/0xtrails/src/widget/components/TokenList.tsx
@@ -164,7 +164,7 @@ export const TokenList: React.FC<TokenListProps> = ({
             <button
               type="button"
               onClick={onBack}
-              className="p-2 rounded-full transition-colors cursor-pointer hover:trails-hover-bg text-gray-400"
+              className="p-2 -ml-2 rounded-full transition-colors cursor-pointer hover:trails-hover-bg text-gray-400"
             >
               <ChevronLeft className="h-6 w-6" />
             </button>


### PR DESCRIPTION
## Summary
• Remove excessive `mr-8` right margin from TokenList total balance container
• Fixes layout styling interference and improves visual consistency

## Test plan
- [x] Verify total balance section no longer has excessive right margin
- [x] Test layout responsiveness across different screen sizes
- [x] Confirm proper alignment with other UI elements